### PR TITLE
Spawn mode updates for nonblocking operation

### DIFF
--- a/eg/echo.pl
+++ b/eg/echo.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use feature qw/ say /;
+
+use MIDI::RtController;
+
+my $in = $ARGV[0] // 'oxy';
+my $out = $ARGV[1] // 'gs';
+
+my $rtc = MIDI::RtController->new( input => $in, output => $out );
+
+push @{ $rtc->_filters->{note_on} }, sub { say join ', ', @{ $_[0] } };
+
+$rtc->run;

--- a/eg/tester.pl
+++ b/eg/tester.pl
@@ -89,3 +89,5 @@ sub delay_tone ($event) {
     }
     return 0;
 }
+
+$rtc->run;

--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.0100';
 
 use Moo;
 use strictures 2;
-use Carp qw(croak);
+use Carp qw(croak carp);
 use Future::AsyncAwait;
 use IO::Async::Channel ();
 use IO::Async::Loop ();
@@ -120,18 +120,27 @@ sub BUILD {
     );
     $self->_loop->add($midi_rtn);
     my $input_name = $self->input;
-    $self->_msg_channel->send(qr/\Q$input_name/i);
+    $self->_msg_channel->send(\$input_name);
 
     $self->_midi_out->open_virtual_port('foo');
-    my $output_name = $self->output;
-    $self->_midi_out->open_port_by_name(qr/\Q$output_name/i);
+    _open_port($self->_midi_out, $self->output);
+}
 
-    $self->_loop->await($self->_process_midi_events());
+sub _log {
+    return unless $ENV{PERL_FUTURE_DEBUG};
+    carp @_;
+}
+
+sub _open_port($device, $name) {
+    _log("Opening $device->{type} port $name ...");
+    $device->open_port_by_name(qr/\Q$name/i) ||
+            croak "Failed to open port $name";
+    _log("Opened $device->{type} port $name");
 }
 
 sub rtmidi_loop ($msg_ch, $midi_ch) {
     my $midi_in = MIDI::RtMidi::FFI::Device->new(type => 'in');
-    $midi_in->open_port_by_name($msg_ch->recv);
+    _open_port($midi_in, ${ $msg_ch->recv });
     $midi_in->set_callback_decoded(sub { $midi_ch->send($_[2]) });
     sleep;
 }

--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -119,6 +119,11 @@ sub BUILD {
         func         => 'rtmidi_loop',
     );
     $self->_loop->add($midi_rtn);
+    $self->_midi_channel->configure(
+        on_recv => sub ($channel, $event) {
+            $self->_filter_and_forward($event);
+        }
+    );
     my $input_name = $self->input;
     $self->_msg_channel->send(\$input_name);
 
@@ -166,12 +171,9 @@ sub _filter_and_forward ($self, $event) {
     $self->send_it($event);
 }
 
-async sub _process_midi_events ($self) {
-    while (my $event = await $self->_msg_channel->recv) {
-        $self->_filter_and_forward($event);
-    }
+sub run ($self) {
+    $self->_loop->run;
 }
-
 
 1;
 __END__


### PR DESCRIPTION
- Removes (blocking) loop start and async function `_process_midi_events`, in favour of a callback
- Adds rudimentary debug output for connections
- Adds a `run` method which starts the loop

Previously, instantiating the class would start the loop in `BUILD`, which would stop any further code being run in the calling client. The caller is now responsible for running the loop via method `run`.

Did some very quick testing with echo.pl (sending note events to alsa midi through in another window):

```
$ perl -Ilib eg/echo.pl through through
note_on, 0, 123, 123
note_on, 0, 123, 123
note_on, 0, 123, 123
```

Adding a callback to the channel was neater than retaining or storing the `_process_midi_events` Future.