### PR TITLE
Event filters which respond to all event types

### DIFF
--- a/eg/echo.pl
+++ b/eg/echo.pl
@@ -14,7 +14,7 @@ my $rtc = MIDI::RtController->new( input => $in, output => $out );
 $rtc->add_filter(
     'echo',
     all => sub {
-        say say "dt: $_[0], ev: ", join( ', ', @{ $_[1] } )
+        say "dt: $_[0], ev: ", join( ', ', @{ $_[1] } )
             unless $_[1]->[0] eq 'clock';
         0;
     }

--- a/eg/echo.pl
+++ b/eg/echo.pl
@@ -14,7 +14,7 @@ my $rtc = MIDI::RtController->new( input => $in, output => $out );
 $rtc->add_filter(
     'echo',
     all => sub {
-        say join ' ', @{ $_[1] }
+        say say "dt: $_[0], ev: ", join( ', ', @{ $_[1] } )
             unless $_[1]->[0] eq 'clock';
     }
 );

--- a/eg/echo.pl
+++ b/eg/echo.pl
@@ -12,8 +12,11 @@ my $out = $ARGV[1] || 'gs';
 my $rtc = MIDI::RtController->new( input => $in, output => $out );
 
 $rtc->add_filter(
-    'say',
-    note_on => sub { say "dt: $_[0], ev: ", join( ', ', @{ $_[1] } ) }
+    'echo',
+    all => sub {
+        say join ' ', @{ $_[1] }
+            unless $_[1]->[0] eq 'clock';
+    }
 );
 
 $rtc->run;

--- a/eg/echo.pl
+++ b/eg/echo.pl
@@ -16,6 +16,7 @@ $rtc->add_filter(
     all => sub {
         say say "dt: $_[0], ev: ", join( ', ', @{ $_[1] } )
             unless $_[1]->[0] eq 'clock';
+        0;
     }
 );
 

--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -198,7 +198,9 @@ sub _rtmidi_loop ($msg_ch, $midi_ch) {
 }
 
 sub _filter_and_forward ($self, $dt, $event) {
-    my $event_filters = $self->filters->{ $event->[0] } // [];
+    my $event_filters = $self->filters->{ 'all' } // [];
+    push @{ $event_filters }, @{ $self->filters->{ $event->[0] } // [] };
+
     for my $filter ($event_filters->@*) {
         return if $filter->($dt, $event);
     }

--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -260,7 +260,7 @@ B<event_type> like C<note_on> or C<note_off>.
 
 sub add_filter ($self, $name, $event_type, $action) {
     if ( ref $event_type eq 'ARRAY' ) {
-        $self->add_filter( $_, $event_type, $action ) for @{ $event_type };
+        $self->add_filter( $name, $_, $action ) for @{ $event_type };
         return;
     }
     _log("Add $name filter for $event_type")

--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -261,6 +261,7 @@ B<event_type> like C<note_on> or C<note_off>.
 sub add_filter ($self, $name, $event_type, $action) {
     if ( ref $event_type eq 'ARRAY' ) {
         $self->add_filter( $_, $event_type, $action ) for @{ $event_type };
+        return;
     }
     _log("Add $name filter for $event_type")
         if $self->verbose;

--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -259,6 +259,9 @@ B<event_type> like C<note_on> or C<note_off>.
 =cut
 
 sub add_filter ($self, $name, $event_type, $action) {
+    if ( ref $event_type eq 'ARRAY' ) {
+        $self->add_filter( $_, $event_type, $action ) for @{ $event_type };
+    }
     _log("Add $name filter for $event_type")
         if $self->verbose;
     push $self->filters->{$event_type}->@*, $action;


### PR DESCRIPTION
# Scenario:

You want to create a MIDI monitor type callback which responds to every event type (for e.g. writing a score of a performance). You need to do:

```perl
$rtc->add_filter('monitor', note_on => \&callback );
$rtc->add_filter('monitor', note_off => \&callback );
$rtc->add_filter('monitor', control_change => \&callback );
$rtc->add_filter('monitor', key_after_touch => \&callback );
$rtc->add_filter('monitor', channel_after_touch => \&callback );
$rtc->add_filter('monitor', pitch_wheel_change => \&callback );
$rtc->add_filter('monitor', patch_change => \&callback );
```

...and so on

# Solution:

The 'all' event type applies your callback to every event type:

```perl
$rtc->add_filter('monitor', all => \&callback );
```

You can do further filtering, e.g. ignoring 'clock' and other events, within the filter (see echo.pl).

# Also

This also adds support for adding multiple event types in an array:

```perl
$rtc->add_filter('name', [ qw/ note_on note_off / ] => \&callback );
```