### PR TITLE
Fix: filter runner shouldn't send, only filters should do this

### DIFF
--- a/lib/MIDI/RtController.pm
+++ b/lib/MIDI/RtController.pm
@@ -202,7 +202,6 @@ sub _filter_and_forward ($self, $dt, $event) {
     for my $filter ($event_filters->@*) {
         return if $filter->($dt, $event);
     }
-    $self->send_it($event);
 }
 
 =head2 send_it


### PR DESCRIPTION
Pretty sure this is a bug carried over from my implementation.